### PR TITLE
feat: skip matchers finished

### DIFF
--- a/adapters/factories/itemmatchercombinerfactory/src/main/java/be/xplore/pricescraper/matchers/factories/ItemMatcherCombinerFactoryImpl.java
+++ b/adapters/factories/itemmatchercombinerfactory/src/main/java/be/xplore/pricescraper/matchers/factories/ItemMatcherCombinerFactoryImpl.java
@@ -2,10 +2,11 @@ package be.xplore.pricescraper.matchers.factories;
 
 import be.xplore.pricescraper.exceptions.CombinerInitializeException;
 import be.xplore.pricescraper.factories.ItemMatcherCombinerFactory;
-import be.xplore.pricescraper.matchers.ItemMatcher;
+import be.xplore.pricescraper.matchers.Combiner;
+import be.xplore.pricescraper.matchers.Matcher;
 import be.xplore.pricescraper.matchers.combiners.WeightedItemMatcherCombiner;
-import be.xplore.pricescraper.utils.matchers.Combiner;
-import be.xplore.pricescraper.utils.matchers.Matcher;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,16 +18,29 @@ import org.springframework.stereotype.Component;
 @Component
 public class ItemMatcherCombinerFactoryImpl implements ItemMatcherCombinerFactory {
 
+  private final List<Matcher> matchers;
+
   @Override
   public Combiner makeWeightedCombiner(Map<Matcher, Double> matchersWithWeights) {
-    if (matchersWithWeights.values().stream().mapToDouble(Double::doubleValue).sum() != 1) {
-      throw new CombinerInitializeException("Sum of weights should be 1");
-    }
+    validateWeights(matchersWithWeights.values());
     WeightedItemMatcherCombiner combiner = new WeightedItemMatcherCombiner();
     for (Map.Entry<Matcher, Double> entry :
         matchersWithWeights.entrySet()) {
-      combiner.addMatcher((ItemMatcher) entry.getKey(), entry.getValue());
+      combiner.addMatcher(entry.getKey());
+      combiner.addWeightToMatcher(entry.getKey().getClass(), entry.getValue());
     }
     return combiner;
   }
+
+  private void validateWeights(Collection<Double> weights) {
+    if (getWeightSum(weights) != 1.0) {
+      throw new CombinerInitializeException(
+          "Matcher Combiner Weight should be 1 after calculating the sum");
+    }
+  }
+
+  private double getWeightSum(Collection<Double> weights) {
+    return weights.stream().mapToDouble(Double::doubleValue).sum();
+  }
+
 }

--- a/adapters/factories/itemmatchercombinerfactory/src/test/java/be/xplore/pricescraper/matchers/factories/ItemMatcherCombinerFactoryTests.java
+++ b/adapters/factories/itemmatchercombinerfactory/src/test/java/be/xplore/pricescraper/matchers/factories/ItemMatcherCombinerFactoryTests.java
@@ -1,12 +1,12 @@
-package be.xplore.pricescraper.matchers;
+package be.xplore.pricescraper.matchers.factories;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import be.xplore.pricescraper.exceptions.CombinerInitializeException;
-import be.xplore.pricescraper.matchers.factories.ItemMatcherCombinerFactoryImpl;
-import be.xplore.pricescraper.utils.matchers.Combiner;
-import be.xplore.pricescraper.utils.matchers.Matcher;
+import be.xplore.pricescraper.matchers.Combiner;
+import be.xplore.pricescraper.matchers.IngredientMatcher;
+import be.xplore.pricescraper.matchers.Matcher;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;

--- a/adapters/matchers/combiners/src/main/java/be/xplore/pricescraper/matchers/combiners/ItemMatcherCombiner.java
+++ b/adapters/matchers/combiners/src/main/java/be/xplore/pricescraper/matchers/combiners/ItemMatcherCombiner.java
@@ -1,39 +1,32 @@
 package be.xplore.pricescraper.matchers.combiners;
 
 import be.xplore.pricescraper.domain.shops.Item;
-import be.xplore.pricescraper.matchers.ItemMatcher;
-import be.xplore.pricescraper.utils.matchers.Combiner;
-import be.xplore.pricescraper.utils.matchers.Matcher;
-import java.util.HashMap;
-import java.util.Map;
+import be.xplore.pricescraper.matchers.Combiner;
+import be.xplore.pricescraper.matchers.Matcher;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Combines multiple matchers and aggregates results.
  */
 public abstract class ItemMatcherCombiner implements Combiner {
-  private final Map<ItemMatcher, Double> matchers = new HashMap<>();
+  private final List<Matcher> matchers = new ArrayList<>();
 
-  protected Map<ItemMatcher, Double> getMatchers() {
+  protected List<Matcher> getMatchers() {
     return matchers;
+  }
+
+  @Override
+  public void addMatcher(Matcher m) {
+    matchers.add(m);
   }
 
   @Override
   public void addItems(Item a, Item b) {
     for (Matcher m :
-        matchers.keySet()) {
+        matchers) {
       m.addItems(a, b);
     }
   }
 
-  /**
-   * Adds a matcher to the combiner.
-   */
-  public void addMatcher(ItemMatcher matcher, double weight) {
-    if (matchers.values().stream().mapToDouble(Double::doubleValue).sum() + weight > 1.0) {
-      throw new IllegalArgumentException(
-          "Matcher Combiner Weight should not go over 1 after calculating the sum");
-    }
-    matchers.put(matcher, weight);
-
-  }
 }

--- a/adapters/matchers/combiners/src/test/java/be/xplore/pricescraper/matchers/combiners/MockItemMatcher.java
+++ b/adapters/matchers/combiners/src/test/java/be/xplore/pricescraper/matchers/combiners/MockItemMatcher.java
@@ -5,6 +5,12 @@ import be.xplore.pricescraper.matchers.ItemMatcher;
 public class MockItemMatcher extends ItemMatcher {
 
   @Override
+  public boolean matchingIsPossible() {
+    return getItemA().getName() != null && getItemB().getName() != null
+        && !getItemA().getName().isEmpty() && !getItemB().getName().isEmpty();
+  }
+
+  @Override
   public double getMatchProbabilityInPercentage() {
     String nameA = getItemA().getName();
     String nameB = getItemA().getName();

--- a/adapters/matchers/combiners/src/test/java/be/xplore/pricescraper/matchers/combiners/WeightedItemMatcherCombinerTests.java
+++ b/adapters/matchers/combiners/src/test/java/be/xplore/pricescraper/matchers/combiners/WeightedItemMatcherCombinerTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import be.xplore.pricescraper.domain.shops.Item;
 import be.xplore.pricescraper.domain.shops.UnitType;
+import be.xplore.pricescraper.exceptions.MatchException;
 import org.junit.jupiter.api.Test;
 
 class WeightedItemMatcherCombinerTests {
@@ -12,37 +13,37 @@ class WeightedItemMatcherCombinerTests {
   private static final WeightedItemMatcherCombiner combiner =
       new WeightedItemMatcherCombiner();
 
-  private static final Item itemA = new Item("", "", 1, UnitType.kg, 1, "");
-  private static final Item itemB = new Item("", "", 1, UnitType.kg, 1, "");
+  private static final Item itemA = new Item("aaaaa", "", 1, UnitType.kg, 1, "");
+  private static final Item itemB = new Item("aaaab", "", 1,
+      UnitType.kg, 1, "");
 
-  static {
-    combiner.addMatcher(new MockItemMatcher(), 0.9);
-    combiner.addMatcher(new MockItemMatcher(), 0.1);
-
-  }
+  private static final Item itemC = new Item("", "", 1,
+      UnitType.kg, 1, "");
 
   @Test
   void combinerShouldHaveMatchPercentage() {
+    combiner.addMatcher(new MockItemMatcher());
     combiner.addItems(itemA, itemB);
+    combiner.addWeightToMatcher(MockItemMatcher.class, 1.0);
+
     double percentage = combiner.getMatchProbabilityInPercentage();
     assertThat(percentage).isPositive();
   }
 
   @Test
   void shouldMatch() {
+    combiner.addMatcher(new MockItemMatcher());
     combiner.addItems(itemA, itemB);
+    combiner.addWeightToMatcher(MockItemMatcher.class, 1.0);
     assertThat(combiner.isMatching()).isTrue();
   }
 
   @Test
-  void combinerShouldThrow() {
-    WeightedItemMatcherCombiner otherCombiner =
-        new WeightedItemMatcherCombiner();
-    otherCombiner.addMatcher(new MockItemMatcher(), 0.5);
-    assertThatThrownBy(
-        () -> otherCombiner.addMatcher(new MockItemMatcher(), 0.7)).isInstanceOf(
-        IllegalArgumentException.class);
-
+  void matchingShouldFail() {
+    combiner.addMatcher(new MockItemMatcher());
+    combiner.addItems(itemA, itemC);
+    combiner.addWeightToMatcher(MockItemMatcher.class, 1.0);
+    assertThatThrownBy(combiner::isMatching).isInstanceOf(MatchException.class);
   }
 
 }

--- a/adapters/matchers/imagerecognitionmatcher/src/main/java/be/xplore/pricescraper/matchers/ImageRecognitionMatcher.java
+++ b/adapters/matchers/imagerecognitionmatcher/src/main/java/be/xplore/pricescraper/matchers/ImageRecognitionMatcher.java
@@ -41,6 +41,12 @@ public class ImageRecognitionMatcher extends ItemMatcher {
   }
 
   @Override
+  public boolean matchingIsPossible() {
+    return getItemA().getImage() != null && getItemB().getImage() != null
+        && !getItemA().getImage().isEmpty() && !getItemB().getImage().isEmpty();
+  }
+
+  @Override
   public boolean isMatching() {
     if (!isInitialized()) {
       throw new MatcherNotInitializedException();

--- a/adapters/matchers/ingredientmatcher/src/main/java/be/xplore/pricescraper/matchers/IngredientMatcher.java
+++ b/adapters/matchers/ingredientmatcher/src/main/java/be/xplore/pricescraper/matchers/IngredientMatcher.java
@@ -13,6 +13,12 @@ public class IngredientMatcher extends ItemMatcher {
       LevenshteinDistance.getDefaultInstance();
   private static final double matchThreshold = 0.8;
 
+  @Override
+  public boolean matchingIsPossible() {
+    return getItemA().getIngredients() != null && getItemB().getIngredients() != null
+        && !getItemA().getIngredients().isEmpty() && !getItemB().getIngredients().isEmpty();
+  }
+
   /**
    * Match 2 items by passing their ingredient strings.
    * Shops often desribe product names slightly different,
@@ -61,5 +67,4 @@ public class IngredientMatcher extends ItemMatcher {
   private String removeLiteralIngredientsString(String ingredients) {
     return ingredients.replace("ingrediënten", "");
   }
-
 }

--- a/adapters/matchers/ingredientmatcher/src/test/java/be/xplore/pricescraper/matchers/ItemIngredientMatcherTests.java
+++ b/adapters/matchers/ingredientmatcher/src/test/java/be/xplore/pricescraper/matchers/ItemIngredientMatcherTests.java
@@ -53,4 +53,13 @@ class ItemIngredientMatcherTests {
     assertThat(notMatched).isFalse();
   }
 
+  @Test
+  void shouldBeAbleToMatch() {
+    IngredientMatcher ingredientMatcher = new IngredientMatcher();
+    ingredientMatcher.addItems(delhaizePizza1, ahPizza1);
+    boolean matchingPossible =
+        ingredientMatcher.matchingIsPossible();
+    assertThat(matchingPossible).isTrue();
+  }
+
 }

--- a/adapters/matchers/itemmatcher/src/main/java/be/xplore/pricescraper/matchers/ItemMatcher.java
+++ b/adapters/matchers/itemmatcher/src/main/java/be/xplore/pricescraper/matchers/ItemMatcher.java
@@ -3,7 +3,6 @@ package be.xplore.pricescraper.matchers;
 
 import be.xplore.pricescraper.domain.shops.Item;
 import be.xplore.pricescraper.exceptions.MatcherNotInitializedException;
-import be.xplore.pricescraper.utils.matchers.Matcher;
 
 /**
  * This is the abstract definition for an ItemMatcher that matches equality of {@link Item}.
@@ -27,6 +26,7 @@ public abstract class ItemMatcher implements Matcher {
     itemB = b;
     initialized = true;
   }
+
 
   /**
    * Normalizes score of matching algorithm to a probability percentage that the items are matching.

--- a/adapters/matchers/titlematcher/src/main/java/be/xplore/pricescraper/matchers/TitleMatcher.java
+++ b/adapters/matchers/titlematcher/src/main/java/be/xplore/pricescraper/matchers/TitleMatcher.java
@@ -13,6 +13,12 @@ public class TitleMatcher extends ItemMatcher {
       LevenshteinDistance.getDefaultInstance();
   private static final double matchThreshold = 0.75;
 
+  @Override
+  public boolean matchingIsPossible() {
+    return getItemA().getName() != null && getItemB().getName() != null
+        && !getItemA().getName().isEmpty() && !getItemB().getName().isEmpty();
+  }
+
   /**
    * Match 2 items by passing their title strings.
    * Shops often desribe product names slightly different.
@@ -52,5 +58,4 @@ public class TitleMatcher extends ItemMatcher {
   private String normalizeTitleString(String title) {
     return MatchStringUtils.normalizeString(title);
   }
-
 }

--- a/adapters/matchers/titlematcher/src/test/java/be/xplore/pricescraper/matchers/TitleMatcherTests.java
+++ b/adapters/matchers/titlematcher/src/test/java/be/xplore/pricescraper/matchers/TitleMatcherTests.java
@@ -42,4 +42,13 @@ class TitleMatcherTests {
     assertThat(notMatched).isFalse();
   }
 
+  @Test
+  void shouldBeAbleToMatch() {
+    TitleMatcher titleMatcher = new TitleMatcher();
+    titleMatcher.addItems(itemA, itemC);
+    boolean matchingPossible =
+        titleMatcher.matchingIsPossible();
+    assertThat(matchingPossible).isTrue();
+  }
+
 }

--- a/application/src/main/java/be/xplore/pricescraper/config/SpringConfig.java
+++ b/application/src/main/java/be/xplore/pricescraper/config/SpringConfig.java
@@ -1,10 +1,10 @@
 package be.xplore.pricescraper.config;
 
 import be.xplore.pricescraper.factories.ItemMatcherCombinerFactory;
+import be.xplore.pricescraper.matchers.Combiner;
 import be.xplore.pricescraper.matchers.IngredientMatcher;
+import be.xplore.pricescraper.matchers.Matcher;
 import be.xplore.pricescraper.matchers.TitleMatcher;
-import be.xplore.pricescraper.utils.matchers.Combiner;
-import be.xplore.pricescraper.utils.matchers.Matcher;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/core/src/main/java/be/xplore/pricescraper/exceptions/CombinerInitializeException.java
+++ b/core/src/main/java/be/xplore/pricescraper/exceptions/CombinerInitializeException.java
@@ -1,11 +1,15 @@
 package be.xplore.pricescraper.exceptions;
 
-import be.xplore.pricescraper.utils.matchers.Combiner;
+import be.xplore.pricescraper.matchers.Combiner;
 
 /**
  * Exception thrown when a {@link Combiner} was not initialized correctly.
  */
 public class CombinerInitializeException extends RuntimeException {
+
+  public CombinerInitializeException() {
+  }
+
   public CombinerInitializeException(String message) {
     super(message);
   }

--- a/core/src/main/java/be/xplore/pricescraper/exceptions/MatcherNotInitializedException.java
+++ b/core/src/main/java/be/xplore/pricescraper/exceptions/MatcherNotInitializedException.java
@@ -1,6 +1,6 @@
 package be.xplore.pricescraper.exceptions;
 
-import be.xplore.pricescraper.utils.matchers.Matcher;
+import be.xplore.pricescraper.matchers.Matcher;
 
 /**
  * Exception thrown when a {@link Matcher} is used before it has been initialized.

--- a/core/src/main/java/be/xplore/pricescraper/factories/ItemMatcherCombinerFactory.java
+++ b/core/src/main/java/be/xplore/pricescraper/factories/ItemMatcherCombinerFactory.java
@@ -1,8 +1,7 @@
 package be.xplore.pricescraper.factories;
 
-
-import be.xplore.pricescraper.utils.matchers.Combiner;
-import be.xplore.pricescraper.utils.matchers.Matcher;
+import be.xplore.pricescraper.matchers.Combiner;
+import be.xplore.pricescraper.matchers.Matcher;
 import java.util.Map;
 
 /**

--- a/core/src/main/java/be/xplore/pricescraper/matchers/Combiner.java
+++ b/core/src/main/java/be/xplore/pricescraper/matchers/Combiner.java
@@ -1,4 +1,4 @@
-package be.xplore.pricescraper.utils.matchers;
+package be.xplore.pricescraper.matchers;
 
 import be.xplore.pricescraper.domain.shops.Item;
 
@@ -7,6 +7,8 @@ import be.xplore.pricescraper.domain.shops.Item;
  */
 public interface Combiner {
   void addItems(Item a, Item b);
+
+  void addMatcher(Matcher m);
 
   boolean isMatching();
 }

--- a/core/src/main/java/be/xplore/pricescraper/matchers/Matcher.java
+++ b/core/src/main/java/be/xplore/pricescraper/matchers/Matcher.java
@@ -1,4 +1,4 @@
-package be.xplore.pricescraper.utils.matchers;
+package be.xplore.pricescraper.matchers;
 
 import be.xplore.pricescraper.domain.shops.Item;
 
@@ -6,6 +6,7 @@ import be.xplore.pricescraper.domain.shops.Item;
  * Interface for matching Objects based on shared characteristics.
  */
 public interface Matcher {
+  boolean matchingIsPossible();
 
   void addItems(Item a, Item b);
 

--- a/core/src/main/java/be/xplore/pricescraper/services/ItemServiceImpl.java
+++ b/core/src/main/java/be/xplore/pricescraper/services/ItemServiceImpl.java
@@ -13,11 +13,11 @@ import be.xplore.pricescraper.exceptions.RootDomainNotFoundException;
 import be.xplore.pricescraper.exceptions.ScrapeItemException;
 import be.xplore.pricescraper.exceptions.ScraperNotFoundException;
 import be.xplore.pricescraper.exceptions.TrackItemException;
+import be.xplore.pricescraper.matchers.Combiner;
 import be.xplore.pricescraper.repositories.ItemPriceRepository;
 import be.xplore.pricescraper.repositories.ItemRepository;
 import be.xplore.pricescraper.repositories.ShopRepository;
 import be.xplore.pricescraper.repositories.TrackedItemRepository;
-import be.xplore.pricescraper.utils.matchers.Combiner;
 import jakarta.transaction.Transactional;
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -285,8 +285,7 @@ public class ItemServiceImpl implements ItemService {
     List<Item> potentialMatches = getPotentialMatchingItems();
     for (Item potentialMatch : potentialMatches) {
       combiner.addItems(potentialMatch, itemToMatch);
-      if (potentialMatch.getIngredients() != null && ingredients != null && title != null
-          && potentialMatch.getName() != null && combiner.isMatching()) {
+      if (combiner.isMatching()) {
         return potentialMatch;
       }
     }


### PR DESCRIPTION
Resolves #79 
- Added skipping of matcher if input data is incorrect
- Combiner now recalculates weights if a matcher was skipped